### PR TITLE
allow localhost as ip address, fix valid port function

### DIFF
--- a/lib/base/setup-device.js
+++ b/lib/base/setup-device.js
@@ -43,11 +43,13 @@ const async = require('async'),
     }
 
     function isValidIpv4(host) {
-        return host.match(/^(\d|[1-9]\d|1\d\d|2([0-4]\d|5[0-5]))\.(\d|[1-9]\d|1\d\d|2([0-4]\d|5[0-5]))\.(\d|[1-9]\d|1\d\d|2([0-4]\d|5[0-5]))\.(\d|[1-9]\d|1\d\d|2([0-4]\d|5[0-5]))$/);
+        return (host === "localhost" ||
+            host.match(/^(\d|[1-9]\d|1\d\d|2([0-4]\d|5[0-5]))\.(\d|[1-9]\d|1\d\d|2([0-4]\d|5[0-5]))\.(\d|[1-9]\d|1\d\d|2([0-4]\d|5[0-5]))\.(\d|[1-9]\d|1\d\d|2([0-4]\d|5[0-5]))$/));
     }
 
     function isValidPort(port) {
-        return String(port).match(/^[0-9]+$/);
+        const intPort = parseInt(port, 10)
+        return intPort > 0 && intPort <= 65535 && String(port) == intPort.toString();
     }
 
     devicetools.showDeviceList = function(next) {


### PR DESCRIPTION
Allow localhost for usage with WSL based devices, or anything else that might be tunnelled via localhost. 127.0.0.1 and localhost are NOT identical in all cases.  

Allow ports from 1-65535, inclusive.