### PR TITLE
Relase 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 3.1.0 (July 15, 2024)
+## 3.1.1 (July 15, 2024)
+### ares-inspec
+* Fixed a bug that ares-inspect --service display error message on webOS 4.5 or lower
+
+
+## 3.1.0 (July 12, 2024)
 ### ares-generate
 * Fixed a bug that can not generate without tample option
 

--- a/lib/base/novacom.js
+++ b/lib/base/novacom.js
@@ -606,6 +606,17 @@ const async = require('async'),
                     log.info("novacom#Session()#begin()", "ssh session event: close (had_error:", had_error, ")");
                 });
                 this.target.readyTimeout = 30000;
+                //Explicit overrides for the default transport layer algorithms used for the connection.
+                this.target.algorithms = {
+                    "kex": [
+                        "diffie-hellman-group1-sha1",
+                        "ecdh-sha2-nistp256",
+                        "ecdh-sha2-nistp384",
+                        "ecdh-sha2-nistp521",
+                        "diffie-hellman-group-exchange-sha256",
+                        "diffie-hellman-group14-sha1"
+                      ],
+                }
                 this.ssh.connect(this.target);
 
                 process.on("SIGHUP", _clearSession);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@webos-tools/cli",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@webos-tools/cli",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webos-tools/cli",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Command Line Interface for development webOS application and service",
   "main": "APIs.js",
   "scripts": {


### PR DESCRIPTION
:Release Notes:
- Fix bug ares-inspect --service on webOS 4.5 or lower,
- Release v3.1.1

:Detailed Notes:
- Fix the bug that async callback already called
- Fix the bug that ssh2 client algorithms config key does not match.
- Update package version 3.1.1 and release note

:Testing Performed:
1. All unit tests passed
2. ESLint done
3. Check the below commands
- $ares -V
   >Version: 3.1.1
- $ares-config -p tv
  >profile and config data is changed to tv
- $ares-shell -r "whoami" -t TARGET
  >TARGET_USER_NAME
- $ares-install PACKAGE_DIR -t TARGET
  >Success
- $ares-launch PACKAGE_ID -t TARGET
   >Launched application PACKAGE_ID
- $ares-inspect -s SERVICE_PACKAGE_ID -t TARGET
  >To debug your service, set "127.0.0.1:[PORT]" on Node's Inspector Client...

:Issues Addressed:
[WRQ-27841][webOS CLI] v3.1.0-T1 [webOS4.5 O18] : Error message observed for service option