### PR TITLE
 [Release 3.1.3] Add native_service for apollo, fixbug ares-setup-device device name with "-"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.1.3 (October 14, 2024)
+### ares-generate
+* Added "native_service" template for apollo platform.
+
+### ares-setup-device
+* Fixed a bug that device name can not be added with "-".
+
 
 ## 3.1.2 (August 07, 2024)
 ### ares-config

--- a/files/conf-base/template-conf/apollo-sdk-templates.json
+++ b/files/conf-base/template-conf/apollo-sdk-templates.json
@@ -43,6 +43,11 @@
         ],
         "description": "services.json, package.json for JS service"
     },
+    "native_service": {
+        "type": "nativeservice",
+        "path": "$cli-root/files/templates/apollo-sdk-templates/native-service",
+        "description": "native service for Apollo"
+    },
     "icon": {
         "type": "icon",
         "path": "$cli-root/files/templates/apollo-sdk-templates/icon",

--- a/files/templates/apollo-sdk-templates/native-service/CMakeLists.txt
+++ b/files/templates/apollo-sdk-templates/native-service/CMakeLists.txt
@@ -1,0 +1,72 @@
+# Copyright (c) 2020-2024 LG Electronics, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 2.8.7)
+project(nativeService C)
+
+# set link directory
+#link_directories(${CMAKE_SOURCE_DIR}/pkg_$ENV{ARCH}/lib)
+
+# ---
+# add include files
+include_directories(${CMAKE_SOURCE_DIR})
+include_directories(${CMAKE_SOURCE_DIR}/src)
+include_directories(${CMAKE_SOURCE_DIR}/include)
+
+# ---
+# find required packages
+include(FindPkgConfig)
+
+pkg_check_modules(GTHREAD2 REQUIRED gthread-2.0)
+include_directories(${GTHREAD2_INCLUDE_DIRS})
+
+pkg_check_modules(PBNJSON REQUIRED pbnjson_c)
+include_directories(${PBNJSON_INCLUDE_DIRS})
+
+# -- check for glib 2.0
+pkg_check_modules(GLIB2 REQUIRED glib-2.0)
+include_directories(${GLIB2_INCLUDE_DIRS})
+
+pkg_check_modules(LS2 REQUIRED luna-service2)
+include_directories(${LS2_INCLUDE_DIRS})
+
+pkg_check_modules(PMLOG REQUIRED PmLogLib)
+include_directories(${PMLOG_INCLUDE_DIRS})
+
+# ---
+# create executable file
+set(BIN_NAME echo_service)
+
+set(SRC_LIST
+    ${CMAKE_SOURCE_DIR}/src/main.c
+)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/pkg_$ENV{OECORE_TARGET_ARCH}/")
+add_executable(${BIN_NAME} ${SRC_LIST})
+
+# ignore shared library
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--allow-shlib-undefined")
+set_target_properties(${BIN_NAME} PROPERTIES LINKER_LANGUAGE C)
+
+target_link_libraries (${BIN_NAME}
+    ${GTHREAD2_LDFLAGS}
+    ${PBNJSON_LDFLAGS}
+    ${LS2_LDFLAGS}
+    ${GLIB2_LDFLAGS}
+    ${PMLOG_LDFLAGS}
+)
+
+file(COPY ${CMAKE_SOURCE_DIR}/services.json DESTINATION "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")

--- a/files/templates/apollo-sdk-templates/native-service/services.json
+++ b/files/templates/apollo-sdk-templates/native-service/services.json
@@ -1,0 +1,11 @@
+{
+    "id": "com.domain.app.service",
+    "description": "Native echo service",
+    "engine": "native",
+    "executable": "echo_service",
+    "services": [ {
+      "name": "com.domain.app.service",
+      "description": "Native echo service"
+    }]
+  }
+  

--- a/files/templates/apollo-sdk-templates/native-service/src/main.c
+++ b/files/templates/apollo-sdk-templates/native-service/src/main.c
@@ -1,0 +1,144 @@
+// Copyright (c) 2020-2024 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdlib.h>
+#include <string.h>
+#include <glib.h>
+#include <stdio.h>
+#include <glib-object.h>
+#include <luna-service2/lunaservice.h>
+#include <pbnjson.h>
+
+// This service name
+#define SERVICE_NAME "SERVICE_ID"
+#define BUF_SIZE 64
+
+// Main loop for aliving background service
+GMainLoop *gmainLoop;
+
+LSHandle  *sh = NULL;
+LSMessage *message;
+
+// Declare of each method
+// All method format must be : bool function(LSHandle*, LSMessage*, void*)
+bool echo(LSHandle *sh, LSMessage *message, void *data);
+
+LSMethod sampleMethods[] = {
+    {"echo", echo},   // luna://SERVICE_ID/echo
+};
+
+
+/*
+ * Define luna://SERVICE_ID/echo
+ *  - A method that always returns the same value
+ *
+ * +----------------------------+            +--------------------------------+
+ * |   APP_ID          |            | SERVICE_ID        |
+ * |   Foreground Application   |            |        Background Service      |
+ * +----------------------------+            +--------------------------------+
+ *   |                                                                        |
+ *   |                                                                        |
+ *   | 1. Request to luna://SERVICE_ID/echo                      |
+ *   |    with parameters { input: "Hello, World!" }                          |
+ *   |                                                                        |
+ *   | ---------------------------------------------------------------------> |
+ *   |                                                                        |
+ *   |                                                                        |
+ *   |            2. Response to APP_ID                              |
+ *   |               with result '{ "echoMessage" : "Hello, World!" }'        |
+ *   |                                                                        |
+ *   | <--------------------------------------------------------------------- |
+ *   |                                                                        |
+ *  \|/                                                                      \|/
+ *   '                                                                        '
+ */
+bool echo(LSHandle *sh, LSMessage *message, void *data)
+{
+    LSError lserror;
+    JSchemaInfo schemaInfo;
+    jvalue_ref parsed = {0}, value = {0};
+    jvalue_ref jobj = {0}, jreturnValue = {0};
+    const char *input = NULL;
+    char buf[BUF_SIZE] = {0, };
+
+    LSErrorInit(&lserror);
+
+    // Initialize schema
+    jschema_info_init (&schemaInfo, jschema_all(), NULL, NULL);
+
+    // get message from LS2 and parsing to make object
+    parsed = jdom_parse(j_cstr_to_buffer(LSMessageGetPayload(message)), DOMOPT_NOOPT, &schemaInfo);
+
+    if (jis_null(parsed)) {
+        j_release(&parsed);
+        return true;
+    }
+
+    // Get value from payload.input
+    value = jobject_get(parsed, j_cstr_to_buffer("input"));
+
+    // JSON Object to string without schema validation check
+    input = jvalue_tostring_simple(value);
+
+    /**
+     * JSON create test
+     */
+    jobj = jobject_create();
+    if (jis_null(jobj)) {
+        j_release(&jobj);
+        return true;
+    }
+
+    jreturnValue = jboolean_create(TRUE);
+    jobject_set(jobj, j_cstr_to_buffer("returnValue"), jreturnValue);
+    jobject_set(jobj, j_cstr_to_buffer("echoMessage"), value);
+
+    LSMessageReply(sh, message, jvalue_tostring_simple(jobj), &lserror);
+
+    j_release(&parsed);
+    return true;
+}
+
+// Register background service and initialize
+int main(int argc, char* argv[])
+{
+    LSError lserror;
+    LSHandle  *handle = NULL;
+    bool bRetVal = FALSE;
+
+    LSErrorInit(&lserror);
+
+    // create a GMainLoop
+    gmainLoop = g_main_loop_new(NULL, FALSE);
+
+    bRetVal = LSRegister(SERVICE_NAME, &handle, &lserror);
+    if (FALSE== bRetVal) {
+        LSErrorFree( &lserror );
+        return 0;
+    }
+    sh = LSMessageGetConnection(message);
+
+    LSRegisterCategory(handle,"/",sampleMethods, NULL, NULL, &lserror);
+
+    LSGmainAttach(handle, gmainLoop, &lserror);
+
+    // run to check continuously for new events from each of the event sources
+    g_main_loop_run(gmainLoop);
+    // Decreases the reference count on a GMainLoop object by one
+    g_main_loop_unref(gmainLoop);
+
+    return 0;
+}

--- a/lib/base/setup-device.js
+++ b/lib/base/setup-device.js
@@ -142,7 +142,10 @@ const async = require('async'),
                 return next(errHndl.getErrMsg("INVALID_MODE"));
             }
             if (options[mode].match(/^-/)) {
-                return next(errHndl.getErrMsg("EMPTY_VALUE", "DEVICE_NAME"));
+                let indexMode = options.argv.cooked.indexOf("--" + mode);
+                if (indexMode != -1 && options.argv.cooked.length > indexMode + 2 && !options.argv.cooked[indexMode + 2].match(/^--[a-z]+$/)) {
+                    return next(errHndl.getErrMsg("EMPTY_VALUE", "DEVICE_NAME"));
+                }
             }
             const argName = (options.info) ? "info" : mode;
             const inDevice = _getParams(options, argName);

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -178,6 +178,31 @@ Generator.prototype.generate = function(options, next) {
                         return;
                     }
                 });
+            } else if (tmplName.match(/(^native_service$)/)) {
+                srcs = [].concat(template.path);
+                return promise.all(srcs.map(function(src) {
+                    return copyToDirAsync(src, dest);
+                })).then(function() {
+                    if(svcinfo.id){
+                        const serviceId = svcinfo.id;
+                        const appId = _appIdFromServiceId(serviceId);
+
+                        //Replace app id and service id
+                        const mainFilePath = path.join(dest,'src','main.c');
+                        let mainFile = fs.readFileSync(mainFilePath, 'utf8');
+                        mainFile = mainFile.replace(/SERVICE_ID/g, serviceId).replace(/APP_ID/g, appId);
+                        fs.writeFileSync(mainFilePath, mainFile, {encoding: 'utf8'});
+
+                        //Replace the default service id 
+                        const serviceInfoFile = path.join(dest,"services.json");
+                        const serviceInfo = readJsonSync(serviceInfoFile)
+                        serviceInfo.id = serviceId;
+                        if(serviceInfo.services && Array.isArray(serviceInfo.services)){
+                            serviceInfo.services[0]['name'] = serviceId;
+                        }
+                        fs.writeFileSync(serviceInfoFile, JSON.stringify(serviceInfo, null, 2));
+                    }
+                });
             } else if (template.type.match(/info$/)) {
                 return _writeMetadata(template, appinfo, svcinfo, pkginfo);
             } else {
@@ -275,6 +300,12 @@ Generator.prototype.generate = function(options, next) {
             log.silly("generator#generate()#_writeURLdata()", "err:", err);
             throw err;
         });
+    }
+
+    function _appIdFromServiceId(serviceId){
+        const svcIdInArray = serviceId.split(".");
+        if(svcIdInArray.length === 1) return serviceId;
+        return svcIdInArray.slice(0,svcIdInArray.length -1).join(".");
     }
 
     function _writeMetadata(metaTmpl, _appinfo, _svcinfo, _pkginfo) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@webos-tools/cli",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@webos-tools/cli",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webos-tools/cli",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Command Line Interface for development webOS application and service",
   "main": "APIs.js",
   "scripts": {


### PR DESCRIPTION
:Release Notes:

ares-generate: new native service template for apollo profile
ares-setup-device: fixed a bug that the device name can not be added with "-".

:Testing Performed:

1. Checked CLI unit test
2. Checked API unit test
3. Checked eslint
4. Check ares-generate using below command
-  $ares-config -p apollo
   > profile and config data is changed to apollo
-  $ares-generate -t native_service SERVICE_DIR
   > Generating native_service in SERVICE_DIR
5. Check ares-setup-device using below command:
- $ares-setup-device --add/-a ---- -i "host=10.123.45.67"
  > New device with name "----" and OPTION has been added

:Issues Addressed: N/A