### PR TITLE
Remove duplicate variable initialization

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -66,7 +66,6 @@ const ar = require('ar-async'),
         this.excludeFiles = [];
         this.sign = null;
         this.certificate = null;
-        this.sign = "";
         this.certificate = "";
         this.appCount = 0;
         this.services = [];


### PR DESCRIPTION
The second `this.sign = ""` causes the explicit null check (`this.sign === null`) to fail later in the code.