### PR TITLE
[Release 3.2.1] Fix an issue on the TV profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.2.1 (April 2, 2025) 
+
+### ares-package
+
+* Fixed a bug related to the use of the `sign` and `certificate` options in `tv` profile.
+
+
 ## 3.2.0 (December 24, 2024) 
 
 ### ares-config

--- a/lib/package.js
+++ b/lib/package.js
@@ -28,7 +28,10 @@ const ar = require('ar-async'),
     // zlib = require('zlib'),
     // tarFilterPack = require('./tar-filter-pack'),
     errHndl = require('./base/error-handler'),
-    tar = require('tar');
+    tar = require('tar'),
+    commonTools = require('./base/common-tools');
+
+const appdata = commonTools.appdata;
 
 (function() {
     log.heading = 'packager';
@@ -1285,6 +1288,7 @@ const ar = require('ar-async'),
                     createDataHash.bind(this, tempCtrlDir, dataTgzFile),
                     createCertificateHash.bind(this, tempCtrlDir),
                     createControlFile.bind(this, tempCtrlDir, false),
+                    createSign.bind(this, tempCtrlDir, dataTgzFile),
                     createControlSignFile.bind(this, tempCtrlDir),
                     makeTgz.bind(this, tempCtrlDir, ctrlTgzFile),
                     createDebianBinary.bind(this, tempDir),
@@ -1367,6 +1371,9 @@ const ar = require('ar-async'),
     }
 
     function createDataHash(dstDir, dataTgzPath, next) {
+        // This function applies only to the signage profile.
+        if (appdata.config.profile !== 'signage') return setImmediate(next);
+
         const self = this;
         log.verbose("package#createDataHash()", "Create data hash");
 
@@ -1403,6 +1410,9 @@ const ar = require('ar-async'),
     }
 
     function createCertificateHash(dstDir, next) {
+        // This function applies only to the signage profile.
+        if (appdata.config.profile !== 'signage') return setImmediate(next);
+
         const self = this;
         try {
             if (!self.certificate) {
@@ -1450,11 +1460,12 @@ const ar = require('ar-async'),
         ];
 
         // To IPK security (SEAL)
-        if (this.sign !== null) {
+        // The data hashs apply only to the signage profile.
+        if (this.sign !== null && appdata.config.profile === 'signage') {
             lines.push('Application-Hash-Algorithm: SHA-256');
             lines.push('Application-Hash: ' + this.dataHash);
         }
-        if (this.certificate !== null) {
+        if (this.certificate !== null && appdata.config.profile === 'signage') {
             lines.push('Certificate-Hash: ' + this.certificateHash);
             lines.push('Signature-Algorithm: RSA');
         }
@@ -1467,6 +1478,9 @@ const ar = require('ar-async'),
     }
 
     function createControlSignFile(ctrlDir, next) {
+        // This function applies only to the signage profile.
+        if (appdata.config.profile !== 'signage') return setImmediate(next);
+
         try {
             if (this.sign === null) {
                 log.verbose("package#createControlSignFile()", "App signing is skipped");
@@ -1497,6 +1511,44 @@ const ar = require('ar-async'),
                 
                 fs.writeFile(controlSignFilePath, base64data, next);
             });
+        } catch (err) {
+            setImmediate(next, err);
+        }
+    }
+
+    function createSign(dstDir, dataTgzPath, next) {
+        // This function does not apply to the signage profile.
+        if (appdata.config.profile === 'signage') return setImmediate(next);
+
+        if ((!this.sign) || (!this.certificate)) {
+            log.verbose("package#createSign()", "App signing is skipped");
+            return setImmediate(next);
+        }
+
+        const sigFilePath = path.join(dstDir, 'data.tar.gz.sha256.txt'),
+            keyPath = path.resolve(this.sign),
+            crtPath = path.resolve(this.certificate);
+
+        log.verbose("package#createSign()", "dataTgzPath:" + dataTgzPath + ", sigfile:" + sigFilePath);
+        log.verbose("package#createSign()", "keyPath:" + keyPath + ", crtPath:" + crtPath);
+
+        try {
+            // Create certificate to tmp/ctrl directory
+            shelljs.cp('-f', crtPath, dstDir);
+
+            // Create signature and write data.tar.gz.sha256.txt
+            const privateKey = fs.readFileSync(keyPath, 'utf-8'),
+                dataFile = fs.readFileSync(dataTgzPath), // data.tar.gz
+                signer = crypto.createSign('sha256');
+
+            signer.update(dataFile);
+            signer.end();
+
+            const signature = signer.sign(privateKey),
+                buff = Buffer.from(signature),
+                base64data = buff.toString('base64');
+
+            fs.writeFile(sigFilePath, base64data, next);
         } catch (err) {
             setImmediate(next, err);
         }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@webos-tools/cli",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@webos-tools/cli",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webos-tools/cli",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Command Line Interface for development webOS application and service",
   "main": "APIs.js",
   "scripts": {


### PR DESCRIPTION
**Release Notes**

* Fix the bug related to --sign & --certificate options in TV profile
* Add change note for 3.2.1 version

**Detailed Notes**

* Update lib/package.js: 
  * skip createDataHash, createCertificateHash and createControlSignFile functions in non-Signage profile
  * skip createSign function in Signage profile
* Update CHANGELOG.md, npm-shrinkwrap.json, package.json: Add change log & update new version (3.2.1)