### PR TITLE
Fix --app-exclude for Linux

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -113,7 +113,7 @@ const appdata = commonTools.appdata;
                 if (options.excludefiles instanceof Array) {
                     this.excludeFiles = options.excludefiles.map(filePath => {
                         if (filePath && filePath.length)
-                            filePath = filePath.replace(/(^\\|^)/i, "\\").replaceAll(/\\/gi, "\\\\");
+                            filePath = filePath.replace(/(^\\|^\/|^)/i, path.sep).replaceAll(/\\/gi, "\\\\");
                         return filePath;
                     });
                 } else {


### PR DESCRIPTION
Uses path.sep instead of `"\\"` for linux compatibility. 

- Tested with `-e test` and confirmed path-to/test was excluded.
- Tested with `-e /test` and confirmed path-to/test was excluded.
