### PR TITLE
Fix Linux simulator launch for AppImage files

### DIFF
--- a/lib/launch.js
+++ b/lib/launch.js
@@ -501,12 +501,19 @@ const appdata = commonTools.appdata,
             function _findSimulatorVersion(fileList, next) {
                 log.silly("launcher#launchSimulator#_findSimulatorVersion():", "fileList:", fileList);
                 let versionList = [];
+                const simulatorExecutablePathByVersion = {};
+
                 for (let i = 0; i < fileList.length; i++) {
                     if (fileList[i].indexOf(options.simulatorPrefix) === 0) {
                         const filePath = path.resolve(options.simulatorDir, fileList[i]);
+                        const ext = path.extname(filePath).toLowerCase();
+
                         if (fs.existsSync(filePath)
-                            && [".exe", ".appimage", ".app"].includes(path.extname(filePath))) {
-                            versionList.push(path.parse(filePath).name.slice(options.simulatorPrefix.length + 1));
+                            && [".exe", ".appimage", ".app"].includes(ext)) {
+                            const version = path.parse(filePath).name.slice(options.simulatorPrefix.length + 1);
+
+                            versionList.push(version);
+                            simulatorExecutablePathByVersion[version] = filePath;
                         }
                     }
                 }
@@ -518,6 +525,7 @@ const appdata = commonTools.appdata,
                         // sort version descending order
                         versionList = versionList.sort(semver.rcompare);
                         options.simulatorVersion = versionList[0];
+                        options.simulatorExecutablePath = simulatorExecutablePathByVersion[options.simulatorVersion];
                         next();
                     } catch(err) {
                         next(err, null);
@@ -526,21 +534,12 @@ const appdata = commonTools.appdata,
             }
 
             function _launchSimulator(next) {
-                let ext = '';
-                switch (process.platform) {
-                    case 'win32':
-                        ext = 'exe';
-                        break;
-                    case 'linux':
-                        ext = 'appimage';
-                        break;
-                    case 'darwin':
-                        ext = 'app';
-                        break;
-                    default:
+                const simulatorPath = options.simulatorExecutablePath;
+
+                if (!simulatorPath) {
+                    return setImmediate(next, errHndl.getErrMsg('EMPTY_VALUE', "simulatorExecutablePath"));
                 }
-                const simulatorName = `${options.simulatorPrefix}_${options.simulatorVersion}`,
-                    simulatorPath = path.join(options.simulatorDir, `${simulatorName}.${ext}`);
+
                 if (!fs.existsSync(simulatorPath)) {
                     return setImmediate(next, errHndl.getErrMsg('NOT_EXIST_PATH', simulatorPath));
                 }


### PR DESCRIPTION
### Issue
Fix Linux webOS TV Simulator detection and launch when the simulator executable uses the standard `.AppImage` extension casing.

On Linux, webOS TV 26 Simulator is distributed as a file named like:

  webOS_TV_26_Simulator_1.5.0.AppImage

The existing simulator discovery checks `path.extname(filePath)` against `.appimage` case-sensitively, so `.AppImage` files are ignored.

Additionally, the launch step reconstructs the executable path using a lowercase `.appimage` extension, which also fails on case-sensitive Linux filesystems.

### Fix
- normalizes the extension check with `.toLowerCase()`
- records the actual matched simulator executable path
- launches the matched executable path instead of reconstructing one with guessed extension casing

### Testing
- Installed `@webos-tools/cli` on Linux using Node 16.
- Downloaded webOS TV 26 Simulator for Linux.
- Confirmed that `ares-launch -s 26 -sp <simulator-dir> <app-dir>` fails before the patch when the simulator file is named `.AppImage`.
- Confirmed that simulator detection uses the matched executable path after the patch.