### PR TITLE
fix: use rimraf named export and Promise API

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -19,7 +19,7 @@ const ar = require('ar-async'),
     mkdirp = require('mkdirp'),
     log = require('npmlog'),
     path = require('path'),
-    rimraf = require('rimraf'),
+    rimraf = require('rimraf').rimraf,
     shelljs = require('shelljs'),
     stripbom = require('strip-bom'),
     temp = require('temp'),
@@ -474,10 +474,10 @@ const appdata = commonTools.appdata;
 
             function _removeTmpDir(next) {
                 log.info("package#analyzeIPK()#_removeTmpDir()");
-                rimraf(tmpDirPath, function(err) {
+                rimraf(tmpDirPath).then(function() {
                     log.verbose("package#analyzeIPK()#_removeTmpDir()", "removed " + tmpDirPath);
-                    next(err);
-                });
+                    next();
+                }, next);
             }
         }
     };
@@ -1702,10 +1702,13 @@ const appdata = commonTools.appdata;
             middleCb("Skipping removal of  " + this.tempDir);
             setImmediate(next);
         } else {
-            rimraf(this.tempDir, function(err) {
-                log.verbose("package#cleanupTmpDir()", "removed " + this.tempDir);
+            const self = this;
+            rimraf(this.tempDir).then(function() {
+                log.verbose("package#cleanupTmpDir()", "removed " + self.tempDir);
+                setImmediate(next);
+            }, function(err) {
                 setImmediate(next, err);
-            }.bind(this));
+            });
         }
     }
 


### PR DESCRIPTION
rimraf removed its default export as of v5, so `require('rimraf')` returns an object rather than a callable function. With rimraf v6 (introduced in 3.2.4) the existing default-import callback usage in lib/package.js throws `TypeError: rimraf is not a function`, which breaks `ares-package`.

Switch to the named export and migrate the two call sites in package.js (_removeTmpDir, cleanupTmpDir) from the callback form to the Promise API, using the two-argument then(onFulfilled, onRejected) form so the success handler and the rejection handler stay separate and `next` is invoked exactly once. Error/flow semantics are preserved (next(err) on failure, next() on success); `this` is captured for cleanupTmpDir.

Supersedes #44.