### PR TITLE
Release v3.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.2.5 (June 29, 2026)
+
+### ares-package
+
+* Updated rimraf to use named export and Promise API for compatibility with rimraf v6.
+* Fixed an issue where ares-package command failed due to rimraf default export changes.
+
 ## 3.2.4 (May 28, 2026)
 
 ### All Platforms

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@webos-tools/cli",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@webos-tools/cli",
-      "version": "3.2.3",
+      "version": "3.2.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webos-tools/cli",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "Command Line Interface for development webOS application and service",
   "main": "APIs.js",
   "scripts": {


### PR DESCRIPTION
- Update version to 3.2.5 in package.json
- Add release notes for v3.2.5 in CHANGELOG.md
- Update npm-shrinkwrap.json for version

Changes included:
- Fixed rimraf named export and Promise API for rimraf v6 compatibility
- Fixed an issue where ares-package command failed due to rimraf default export changes